### PR TITLE
对博客设置进行补充说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Theme for <http://linianhui.cnblogs.com> .
 
 主题 : `LessIsMore`
 
+页面定制 CSS 代码：勾选 "禁用模板默认CSS"
+
 页首代码
 ```html
 <script type="text/javascript">$("#mobile-style").remove();</script>


### PR DESCRIPTION
我在按照您的教程设置时，出现了和您的博客显示不一致的情况，如下图所示
![image](https://user-images.githubusercontent.com/74233307/186838397-61c7c23e-9057-40c5-9e8e-31f44360d76d.png)
我发现必须在博客园的”页面定制 CSS 代码“中，勾选”禁用模板默认CSS“，才能解决显示错乱的问题。
因此提 PR 对博客设置进行补充说明，让想用此样式的博客作者更方便快捷。

我觉得您的这个侧边栏目录非常的好，这也是我使用您这个样式的原因，太棒了。